### PR TITLE
feat: allow question mark tile markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A browser-based roguelike twist on the classic Minesweeper game. Navigate progre
 - **Gold economy:** Earn gold from safe tiles and use it to purchase upgrades or items.
 - **Permanent upgrade shop:** Spend end-of-run gold on upgrades like extra shields or starting gold to power up future runs.
 - **Inter-level item shop:** Buy temporary items with rarity-based loot to aid in the next level.
+- **Flag cycle:** Right-click tiles to cycle between a flag, a question mark for uncertain tiles, and a blank state.
 - **Responsive design:** Built with Tailwind CSS and custom fonts for a retro sci-fi feel.
 
 ## Getting Started

--- a/src/main.js
+++ b/src/main.js
@@ -144,7 +144,20 @@ function applyStartOfLevelBuffs() {
 }
 
 function createGrid() {
-    state.grid = Array(state.rows).fill(null).map(() => Array(state.cols).fill(null).map(() => ({ isMine: false, isRevealed: false, isFlagged: false, isExit: false, adjacentMines: 0 })));
+    state.grid = Array(state.rows)
+        .fill(null)
+        .map(() =>
+            Array(state.cols)
+                .fill(null)
+                .map(() => ({
+                    isMine: false,
+                    isRevealed: false,
+                    isFlagged: false,
+                    isQuestion: false,
+                    isExit: false,
+                    adjacentMines: 0,
+                }))
+        );
     let minesToPlace = state.mineCount;
     while (minesToPlace > 0) {
         const r = Math.floor(Math.random() * state.rows);
@@ -177,6 +190,7 @@ function renderGrid() {
             cellEl.className = 'cell';
             cellEl.dataset.row = r; cellEl.dataset.col = c;
             if (cellData.isFlagged) { cellEl.classList.add('flagged'); cellEl.textContent = '⚑'; }
+            else if (cellData.isQuestion) { cellEl.classList.add('question'); cellEl.textContent = '?'; }
             else if (cellData.isRevealed) {
                 cellEl.classList.add('revealed');
                 if (cellData.isMine) { cellEl.classList.add('mine'); cellEl.textContent = '✸'; }
@@ -280,15 +294,26 @@ function handleRightClick(e) {
     if (!cellEl) return;
     const row = parseInt(cellEl.dataset.row);
     const col = parseInt(cellEl.dataset.col);
-    if (state.grid[row][col].isRevealed) return;
-    state.grid[row][col].isFlagged = !state.grid[row][col].isFlagged;
-    state.flagsPlaced += state.grid[row][col].isFlagged ? 1 : -1;
-    renderGrid(); updateUI();
+    const cell = state.grid[row][col];
+    if (cell.isRevealed) return;
+    if (!cell.isFlagged && !cell.isQuestion) {
+        cell.isFlagged = true;
+        state.flagsPlaced++;
+    } else if (cell.isFlagged) {
+        cell.isFlagged = false;
+        cell.isQuestion = true;
+        state.flagsPlaced--;
+    } else if (cell.isQuestion) {
+        cell.isQuestion = false;
+    }
+    renderGrid();
+    updateUI();
 }
 
 function revealCell(row, col, silent = false) {
     const cellData = state.grid[row][col];
     if (cellData.isRevealed || cellData.isFlagged) return;
+    if (cellData.isQuestion) cellData.isQuestion = false;
     cellData.isRevealed = true;
     state.revealedCount++;
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -38,6 +38,10 @@ body {
     background-color: #4B5563;
     color: #FBBF24;
 }
+.cell.question {
+    background-color: #4B5563;
+    color: #93C5FD;
+}
 .cell.mine {
     background-color: #EF4444;
     color: #111827;


### PR DESCRIPTION
## Summary
- add third state for right-click cycle to place question mark markers
- style question-marked tiles
- document new question mark cycle in README

## Testing
- `node --check src/main.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5a53c37c8324b236beb69c4f9c72