### PR TITLE
fix: preserve item cost in shop

### DIFF
--- a/src/shop.js
+++ b/src/shop.js
@@ -93,6 +93,10 @@ function populateItemShop() {
         itemEl.className = `shop-item bg-gray-700 p-4 rounded-lg flex flex-col justify-between border-2 ${item.rarityClass}`;
         itemEl.dataset.itemId = item.id;
         itemEl.dataset.itemRarity = item.rarity;
+        // Store cost so it can be referenced later when resetting buttons
+        // after a purchase. Without this, non-selected items lose their cost
+        // information and display "BUY (undefined G)".
+        itemEl.dataset.itemCost = item.cost;
 
         itemEl.innerHTML = `
             <div>


### PR DESCRIPTION
## Summary
- keep item cost on shop elements to prevent undefined price labels after purchases

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7e037e1c8324bc2a215c74c9bec0