### PR TITLE
Swap mines for monsters in dungeon theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Rogue Minesweeper
+# Rogue Monster Sweeper
 
-A browser-based roguelike twist on the classic Minesweeper game. Navigate progressively larger minefields, collect gold, and buy upgrades to push deeper each run.
+A browser-based roguelike twist on the classic Minesweeper game. Explore progressively larger dungeons filled with hidden monsters, collect gold, and buy upgrades to push deeper each run.
 
 ## Features
 
-- **Progressive difficulty** – grid size and mine density grow with each level, challenging your deduction skills.
+- **Progressive difficulty** – grid size and monster density grow with each level, challenging your deduction skills.
 - **Lives and shields** – start with three hearts and burn through shields before losing lives.
 - **Gold economy** – earn gold from safe tiles and level completion to spend on upgrades and items.
 - **Permanent upgrade shop** – invest end-of-run gold on long-term upgrades like extra lives or starting gold.
 - **Inter-level item shop** – purchase temporary buffs between levels from a rarity-based item pool.
 - **Inventory & highscores** – track permanent upgrades, active buffs, highest level reached and max gold earned.
 - **Flag cycle** – right-click tiles to cycle between flag, question mark and blank states.
-- **Responsive design** – Tailwind CSS and custom fonts provide a retro sci-fi feel.
+- **Responsive design** – Tailwind CSS and custom fonts provide a retro fantasy feel.
 
 ## Getting Started
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rogue Minesweeper</title>
+    <title>Rogue Monster Sweeper</title>
     <script src="https://cdn.tailwindcss.com"></script>
     
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -14,12 +14,12 @@
 <body class="flex items-center justify-center min-h-screen py-4">
 
     <div id="game-container" class="flex flex-col items-center p-4 space-y-4 w-full max-w-7xl">
-        <h1 class="text-4xl md:text-5xl font-orbitron text-green-400 tracking-widest">ROGUE MINESWEEPER</h1>
+        <h1 class="text-4xl md:text-5xl font-orbitron text-green-400 tracking-widest">ROGUE MONSTER SWEEPER</h1>
 
         <div id="status-bar" class="status-bar w-full max-w-4xl grid grid-cols-2 sm:grid-cols-4 gap-2 text-center text-lg">
             <div class="bg-gray-800 p-2 rounded-lg border border-gray-700">LVL: <span id="level">1</span></div>
             <div class="bg-gray-800 p-2 rounded-lg border border-gray-700">HEALTH: <span id="health">❤️❤️❤️</span></div>
-            <div class="bg-gray-800 p-2 rounded-lg border border-gray-700">MINES: <span id="mines-left">10</span></div>
+            <div class="bg-gray-800 p-2 rounded-lg border border-gray-700">MONSTERS: <span id="monsters-left">10</span></div>
             <div class="bg-gray-800 p-2 rounded-lg border border-gray-700">GOLD: <span id="gold">0</span></div>
         </div>
 

--- a/src/data/permanentUpgrades.js
+++ b/src/data/permanentUpgrades.js
@@ -1,6 +1,6 @@
 export const permanentUpgrades = {
     maxLives: {
-        name: 'Reinforced Hull',
+        name: 'Blessed Armor',
         description: 'Increase max lives by 1.',
         baseCost: 50,
         costIncrease: 2,
@@ -11,7 +11,7 @@ export const permanentUpgrades = {
         },
     },
     startingGold: {
-        name: 'Gold Scanner',
+        name: 'Treasure Map',
         description: 'Start each run with extra gold.',
         baseCost: 100,
         costIncrease: 1.8,
@@ -22,8 +22,8 @@ export const permanentUpgrades = {
         },
     },
     firstClickSafety: {
-        name: 'Mine Deflector',
-        description: 'Your first click on a mine each level will flag it instead.',
+        name: 'Monster Ward',
+        description: 'Your first click on a monster each level will flag it instead.',
         baseCost: 750,
         unlocked: false,
         apply(playerStats) {

--- a/src/data/temporaryItems.js
+++ b/src/data/temporaryItems.js
@@ -21,7 +21,7 @@ export const temporaryItems = {
         {
             id: 'c3',
             name: 'Steady Hand',
-            description: 'The next mine you hit will not consume a life.',
+            description: 'The next monster you hit will not consume a life.',
             cost: 40,
             apply(state) {
                 state.nextLevelBuffs.steadyHand = true;
@@ -67,11 +67,11 @@ export const temporaryItems = {
         },
         {
             id: 'u3',
-            name: 'Bomb Squad',
-            description: 'Automatically flags 2 random mines at the start of the next level.',
+            name: 'Monster Tracker',
+            description: 'Automatically flags 2 random monsters at the start of the next level.',
             cost: 75,
             apply(state) {
-                state.nextLevelBuffs.bombSquad = (state.nextLevelBuffs.bombSquad || 0) + 2;
+                state.nextLevelBuffs.monsterTracker = (state.nextLevelBuffs.monsterTracker || 0) + 2;
             },
         },
         {
@@ -106,7 +106,7 @@ export const temporaryItems = {
         {
             id: 'r2',
             name: 'Forcefield',
-            description: 'Become immune to mine damage for the next 10 clicks.',
+            description: 'Become immune to monster attacks for the next 10 clicks.',
             cost: 120,
             apply(state) {
                 state.nextLevelBuffs.forcefield = (state.nextLevelBuffs.forcefield || 0) + 10;
@@ -123,11 +123,11 @@ export const temporaryItems = {
         },
         {
             id: 'r4',
-            name: 'Elite Bomb Squad',
-            description: 'Automatically flags 25% of all mines at the next level.',
+            name: 'Elite Monster Tracker',
+            description: 'Automatically flags 25% of all monsters at the next level.',
             cost: 200,
             apply(state) {
-                state.nextLevelBuffs.eliteBombSquad = true;
+                state.nextLevelBuffs.eliteMonsterTracker = true;
             },
         },
     ],
@@ -143,11 +143,11 @@ export const temporaryItems = {
         },
         {
             id: 'l2',
-            name: 'Mine Neutralizer',
-            description: 'Removes 10% of the mines from the next level.',
+            name: 'Monster Repellent',
+            description: 'Removes 10% of the monsters from the next level.',
             cost: 300,
             apply(state) {
-                state.nextLevelBuffs.mineNeutralizer = true;
+                state.nextLevelBuffs.monsterRepellent = true;
             },
         },
         {

--- a/src/game.js
+++ b/src/game.js
@@ -42,14 +42,14 @@ export function startLevel() {
 
     state.rows = Math.min(8 + state.level, 20);
     state.cols = Math.min(8 + state.level, 30);
-    state.mineCount = Math.min(
+    state.monsterCount = Math.min(
         5 + Math.floor(state.level * 2.5),
         Math.floor(state.rows * state.cols * 0.3)
     );
 
-    if (state.activeBuffs.mineNeutralizer) {
-        state.mineCount = Math.floor(state.mineCount * 0.9);
-        delete state.activeBuffs.mineNeutralizer;
+    if (state.activeBuffs.monsterRepellent) {
+        state.monsterCount = Math.floor(state.monsterCount * 0.9);
+        delete state.activeBuffs.monsterRepellent;
     }
 
     dom.messageAreaEl.textContent = `Level ${state.level}: Find the exit!`;
@@ -69,7 +69,7 @@ function applyStartOfLevelBuffs() {
         for (let i = 0; i < 1000 && toReveal > 0; i++) {
             const r = Math.floor(Math.random() * state.rows);
             const c = Math.floor(Math.random() * state.cols);
-            if (!state.grid[r][c].isMine && !state.grid[r][c].isRevealed) {
+            if (!state.grid[r][c].isMonster && !state.grid[r][c].isRevealed) {
                 revealCell(r, c, true);
                 toReveal--;
             }
@@ -79,38 +79,38 @@ function applyStartOfLevelBuffs() {
     if (state.activeBuffs.masterGoggles) {
         for (let r = 0; r < state.rows; r++) {
             for (let c = 0; c < state.cols; c++) {
-                if (state.grid[r][c].adjacentMines === 0 && !state.grid[r][c].isMine) {
+                if (state.grid[r][c].adjacentMonsters === 0 && !state.grid[r][c].isMonster) {
                     revealCell(r, c);
                 }
             }
         }
         delete state.activeBuffs.masterGoggles;
     }
-    if (state.activeBuffs.bombSquad) {
-        let toFlag = state.activeBuffs.bombSquad;
+    if (state.activeBuffs.monsterTracker) {
+        let toFlag = state.activeBuffs.monsterTracker;
         for (let i = 0; i < 1000 && toFlag > 0; i++) {
             const r = Math.floor(Math.random() * state.rows);
             const c = Math.floor(Math.random() * state.cols);
-            if (state.grid[r][c].isMine && !state.grid[r][c].isFlagged) {
+            if (state.grid[r][c].isMonster && !state.grid[r][c].isFlagged) {
                 state.grid[r][c].isFlagged = true;
                 state.flagsPlaced++;
                 toFlag--;
             }
         }
-        delete state.activeBuffs.bombSquad;
+        delete state.activeBuffs.monsterTracker;
     }
-    if (state.activeBuffs.eliteBombSquad) {
-        let minesToFlag = Math.floor(state.mineCount * 0.25);
-        for (let r = 0; r < state.rows && minesToFlag > 0; r++) {
-            for (let c = 0; c < state.cols && minesToFlag > 0; c++) {
-                if (state.grid[r][c].isMine && !state.grid[r][c].isFlagged) {
+    if (state.activeBuffs.eliteMonsterTracker) {
+        let monstersToFlag = Math.floor(state.monsterCount * 0.25);
+        for (let r = 0; r < state.rows && monstersToFlag > 0; r++) {
+            for (let c = 0; c < state.cols && monstersToFlag > 0; c++) {
+                if (state.grid[r][c].isMonster && !state.grid[r][c].isFlagged) {
                     state.grid[r][c].isFlagged = true;
                     state.flagsPlaced++;
-                    minesToFlag--;
+                    monstersToFlag--;
                 }
             }
         }
-        delete state.activeBuffs.eliteBombSquad;
+        delete state.activeBuffs.eliteMonsterTracker;
     }
 }
 
@@ -121,38 +121,38 @@ function createGrid() {
             Array(state.cols)
                 .fill(null)
                 .map(() => ({
-                    isMine: false,
+                    isMonster: false,
                     isRevealed: false,
                     isFlagged: false,
                     isQuestion: false,
                     isExit: false,
-                    adjacentMines: 0,
+                    adjacentMonsters: 0,
                 }))
         );
-    let minesToPlace = state.mineCount;
-    while (minesToPlace > 0) {
+    let monstersToPlace = state.monsterCount;
+    while (monstersToPlace > 0) {
         const r = Math.floor(Math.random() * state.rows);
         const c = Math.floor(Math.random() * state.cols);
-        if (!state.grid[r][c].isMine) {
-            state.grid[r][c].isMine = true;
-            minesToPlace--;
+        if (!state.grid[r][c].isMonster) {
+            state.grid[r][c].isMonster = true;
+            monstersToPlace--;
         }
     }
     for (let r = 0; r < state.rows; r++) {
         for (let c = 0; c < state.cols; c++) {
-            if (state.grid[r][c].isMine) continue;
+            if (state.grid[r][c].isMonster) continue;
             let count = 0;
             for (let dr = -1; dr <= 1; dr++) {
                 for (let dc = -1; dc <= 1; dc++) {
                     if (dr === 0 && dc === 0) continue;
                     const nr = r + dr;
                     const nc = c + dc;
-                    if (nr >= 0 && nr < state.rows && nc >= 0 && nc < state.cols && state.grid[nr][nc].isMine) {
+                    if (nr >= 0 && nr < state.rows && nc >= 0 && nc < state.cols && state.grid[nr][nc].isMonster) {
                         count++;
                     }
                 }
             }
-            state.grid[r][c].adjacentMines = count;
+            state.grid[r][c].adjacentMonsters = count;
         }
     }
 }
@@ -170,8 +170,8 @@ export function handleLeftClick(e) {
 
     if (state.isFirstClick) {
         state.isFirstClick = false;
-        if (playerStats.firstClickSafety && cellData.isMine) {
-            dom.messageAreaEl.textContent = 'Mine Deflector activated!';
+        if (playerStats.firstClickSafety && cellData.isMonster) {
+            dom.messageAreaEl.textContent = 'Monster Ward activated!';
             cellData.isFlagged = true;
             state.flagsPlaced++;
             updateUI(state);
@@ -188,8 +188,8 @@ export function handleLeftClick(e) {
 
     if (state.activeBuffs.forcefield > 0) {
         state.activeBuffs.forcefield--;
-        if (cellData.isMine) {
-            dom.messageAreaEl.textContent = 'Forcefield absorbed the blast!';
+        if (cellData.isMonster) {
+            dom.messageAreaEl.textContent = 'Forcefield absorbed the attack!';
             cellData.isFlagged = true;
             state.flagsPlaced++;
             updateUI(state);
@@ -236,14 +236,14 @@ function revealCell(row, col, silent = false) {
     cellData.isRevealed = true;
     state.revealedCount++;
 
-    if (cellData.isMine) {
-        handleMineHit();
+    if (cellData.isMonster) {
+        handleMonsterHit();
     } else {
         let goldGained = 1;
         if (state.activeBuffs.goldMagnet) goldGained *= 2;
         if (state.activeBuffs.scrapMetal && state.revealedCount % 10 === 0) goldGained++;
         state.gold += goldGained;
-        if (cellData.adjacentMines === 0 && !silent) floodFill(row, col);
+        if (cellData.adjacentMonsters === 0 && !silent) floodFill(row, col);
     }
     updateUI(state);
 }
@@ -263,7 +263,7 @@ function floodFill(row, col) {
     }
 }
 
-function handleMineHit() {
+function handleMonsterHit() {
     if (state.activeBuffs.steadyHand) {
         delete state.activeBuffs.steadyHand;
         dom.messageAreaEl.textContent = 'Steady Hand saved you!';
@@ -295,7 +295,7 @@ function handleMineHit() {
 }
 
 function checkWinCondition() {
-    const safeCells = state.rows * state.cols - state.mineCount;
+    const safeCells = state.rows * state.cols - state.monsterCount;
     if (state.revealedCount >= safeCells) {
         dom.messageAreaEl.textContent = 'All clear! The exit is revealed.';
         if (state.activeBuffs.shieldBattery && !state.damageTakenThisLevel) {
@@ -310,7 +310,7 @@ function checkWinCondition() {
 function placeExit() {
     for (let r = state.rows - 1; r >= 0; r--) {
         for (let c = state.cols - 1; c >= 0; c--) {
-            if (state.grid[r][c].isRevealed && !state.grid[r][c].isMine && state.grid[r][c].adjacentMines === 0) {
+            if (state.grid[r][c].isRevealed && !state.grid[r][c].isMonster && state.grid[r][c].adjacentMonsters === 0) {
                 state.grid[r][c].isExit = true;
                 return;
             }
@@ -318,7 +318,7 @@ function placeExit() {
     }
     for (let r = 0; r < state.rows; r++) {
         for (let c = 0; c < state.cols; c++) {
-            if (state.grid[r][c].isRevealed && !state.grid[r][c].isMine) {
+            if (state.grid[r][c].isRevealed && !state.grid[r][c].isMonster) {
                 state.grid[r][c].isExit = true;
                 return;
             }
@@ -348,7 +348,7 @@ function endRun() {
     dom.messageAreaEl.textContent = 'Run over! Lives depleted.';
     for (let r = 0; r < state.rows; r++) {
         for (let c = 0; c < state.cols; c++) {
-            if (state.grid[r][c].isMine) state.grid[r][c].isRevealed = true;
+            if (state.grid[r][c].isMonster) state.grid[r][c].isRevealed = true;
         }
     }
     renderGrid(state);

--- a/src/state.js
+++ b/src/state.js
@@ -28,7 +28,7 @@ export function resetState() {
         grid: [],
         rows: 0,
         cols: 0,
-        mineCount: 0,
+        monsterCount: 0,
         revealedCount: 0,
         flagsPlaced: 0,
         activeBuffs: {},

--- a/src/ui.js
+++ b/src/ui.js
@@ -9,7 +9,7 @@ export const dom = {
     gridElement: document.getElementById('game-grid'),
     levelEl: document.getElementById('level'),
     healthEl: document.getElementById('health'),
-    minesLeftEl: document.getElementById('mines-left'),
+    monstersLeftEl: document.getElementById('monsters-left'),
     goldEl: document.getElementById('gold'),
     messageAreaEl: document.getElementById('message-area'),
     inventoryContainerEl: document.getElementById('inventory-container'),
@@ -45,15 +45,15 @@ export function renderGrid(state) {
                 cellEl.textContent = '?';
             } else if (cellData.isRevealed) {
                 cellEl.classList.add('revealed');
-                if (cellData.isMine) {
-                    cellEl.classList.add('mine');
-                    cellEl.textContent = '✸';
+                if (cellData.isMonster) {
+                    cellEl.classList.add('monster');
+                    cellEl.textContent = '👾';
                 } else if (cellData.isExit) {
                     cellEl.classList.add('exit');
                     cellEl.textContent = '▼';
-                } else if (cellData.adjacentMines > 0) {
-                    cellEl.textContent = cellData.adjacentMines;
-                    cellEl.classList.add(`text-c-${cellData.adjacentMines}`);
+                } else if (cellData.adjacentMonsters > 0) {
+                    cellEl.textContent = cellData.adjacentMonsters;
+                    cellEl.classList.add(`text-c-${cellData.adjacentMonsters}`);
                 }
             }
             gridElement.appendChild(cellEl);
@@ -65,7 +65,7 @@ export function renderGrid(state) {
 export function updateUI(state) {
     dom.levelEl.textContent = state.level;
     dom.healthEl.innerHTML = '🛡️'.repeat(state.shields) + '❤️'.repeat(state.lives);
-    dom.minesLeftEl.textContent = state.mineCount - state.flagsPlaced;
+    dom.monstersLeftEl.textContent = state.monsterCount - state.flagsPlaced;
     dom.goldEl.textContent = state.gold;
 }
 
@@ -115,12 +115,12 @@ export function renderInventory(state) {
             case 'scrapMetal': return 'Scrap Metal';
             case 'shields': return `+${value} Shield${value > 1 ? 's' : ''}`;
             case 'goldMagnet': return 'Gold Magnet';
-            case 'bombSquad': return `Bomb Squad x${value}`;
+            case 'monsterTracker': return `Monster Tracker x${value}`;
             case 'shieldBattery': return 'Shield Battery';
             case 'forcefield': return `Forcefield (${value})`;
             case 'masterGoggles': return 'Master Goggles';
-            case 'eliteBombSquad': return 'Elite Bomb Squad';
-            case 'mineNeutralizer': return 'Mine Neutralizer';
+            case 'eliteMonsterTracker': return 'Elite Monster Tracker';
+            case 'monsterRepellent': return 'Monster Repellent';
             case 'extraLife': return 'Extra Life';
             case 'goldenGoose': return 'Golden Goose';
             default: return key;

--- a/styles/style.css
+++ b/styles/style.css
@@ -42,8 +42,8 @@ body {
     background-color: #4B5563;
     color: #93C5FD;
 }
-.cell.mine {
-    background-color: #EF4444;
+.cell.monster {
+    background-color: #9333EA;
     color: #111827;
 }
 .cell.exit {


### PR DESCRIPTION
## Summary
- Retheme project to "Rogue Monster Sweeper" with monsters replacing mines throughout docs and UI.
- Track monsters in game logic and adjust buffs like Monster Tracker and Monster Repellent.
- Update styling and items for fantasy flavor, including new monster graphics and labels.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f80c256f48324893bfe0b5139beda